### PR TITLE
Add trigger/event key handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Add trigger/event key handling.
+
 ## [0.1.1]
 
 ### Changed

--- a/src/relay_sdk/events.py
+++ b/src/relay_sdk/events.py
@@ -13,18 +13,27 @@ class Events:
     def __init__(self, client: Session) -> None:
         self._client = client
 
-    def emit(self, data: Mapping[str, Any]) -> None:
-        """Create and send an event to the service.
+    def emit(self, data: Mapping[str, Any], key: Any = None) -> None:
+        """Sends an event to the service.
 
         Use this from a Trigger handler to start the workflow
         associated with the trigger.
 
-        Accepts a Mapping of data fields that will bind
-        names of workflow parameters to values from the
-        request payload that came in to the Trigger handler"""
+        Accepts a Mapping of data fields from the request payload
+        that came in to the Trigger handler.
+
+        A key can be optionally provided to uniquely identify
+        the event."""
+
+        if key is not None:
+            data = {'data': data, 'key': key}
+        else:
+            data = {'data': data}
+
         r = self._client.post(
             'http+api://api/events',
-            data=json.dumps({'data': data}, cls=JSONEncoder),
+            data=json.dumps(data, cls=JSONEncoder),
             headers={'content-type': 'application/json'},
         )
+
         r.raise_for_status()

--- a/src/relay_sdk/events.py
+++ b/src/relay_sdk/events.py
@@ -1,6 +1,6 @@
 "Generating events for the service to act on"
 import json
-from typing import Any, Mapping
+from typing import Any, Dict, Mapping, Optional
 
 from requests import Session
 
@@ -13,7 +13,7 @@ class Events:
     def __init__(self, client: Session) -> None:
         self._client = client
 
-    def emit(self, data: Mapping[str, Any], key: Any = None) -> None:
+    def emit(self, data: Mapping[str, Any], key: Optional[str] = None) -> None:
         """Sends an event to the service.
 
         Use this from a Trigger handler to start the workflow
@@ -25,14 +25,13 @@ class Events:
         A key can be optionally provided to uniquely identify
         the event."""
 
-        if key is not None:
-            data = {'data': data, 'key': key}
-        else:
-            data = {'data': data}
+        post_data: Dict[str, Any] = {'data': data}
+        if key:
+            post_data['key'] = key
 
         r = self._client.post(
             'http+api://api/events',
-            data=json.dumps(data, cls=JSONEncoder),
+            data=json.dumps(post_data, cls=JSONEncoder),
             headers={'content-type': 'application/json'},
         )
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -24,4 +24,5 @@ class TestEvents:
             additional_matcher=lambda request:
                 request.json() == {'data': {'foo': 'bar'}, 'key': 'key'},
         )
-        Events(new_session(api_url='http://api')).emit({'foo': 'bar'}, "key")
+        Events(new_session(api_url='http://api')
+               ).emit({'foo': 'bar'}, key='key')

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,6 +1,7 @@
+from requests_mock import Adapter
+
 from relay_sdk.client import new_session
 from relay_sdk.events import Events
-from requests_mock import Adapter
 
 
 class TestEvents:
@@ -14,3 +15,13 @@ class TestEvents:
                 request.json() == {'data': {'foo': 'bar'}},
         )
         Events(new_session(api_url='http://api')).emit({'foo': 'bar'})
+
+    def test_emit_with_key(self, requests_mock: Adapter) -> None:
+        requests_mock.register_uri(
+            'POST', 'http+api://api/events',
+            text='OK',
+            request_headers={'content-type': 'application/json'},
+            additional_matcher=lambda request:
+                request.json() == {'data': {'foo': 'bar'}, 'key': 'key'},
+        )
+        Events(new_session(api_url='http://api')).emit({'foo': 'bar'}, "key")

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,6 +1,7 @@
 import pytest
-from relay_sdk.interface import Dynamic, Interface, UnresolvableException
 from requests_mock import Adapter
+
+from relay_sdk.interface import Dynamic, Interface, UnresolvableException
 
 
 @pytest.mark.parametrize(

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -1,6 +1,7 @@
+from requests_mock import Adapter
+
 from relay_sdk.client import new_session
 from relay_sdk.outputs import Outputs
-from requests_mock import Adapter
 
 
 class TestOutputs:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,6 +5,7 @@ import signal
 from typing import Any
 
 import pytest
+
 from relay_sdk.util import (JSONEncoder, SignalTerminationPolicy,
                             is_async_callable, json_object_hook)
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -6,11 +6,12 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Mapping, Union
 import pytest
 from hypercorn.typing import ASGIFramework
 from quart import Quart
-from relay_sdk.util import SoftTerminationPolicy
-from relay_sdk.webhook import WebhookServer
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
+
+from relay_sdk.util import SoftTerminationPolicy
+from relay_sdk.webhook import WebhookServer
 
 if TYPE_CHECKING:
     from wsgiref.types import StartResponse, WSGIApplication

--- a/tox.ini
+++ b/tox.ini
@@ -23,13 +23,13 @@ deps =
     {[base]deps}
     check-manifest
     flake8
-    isort
+    isort>=5
     mypy
 ignore_errors = true
 commands =
     check-manifest {toxinidir}
     flake8 src tests setup.py
-    isort --check-only --diff --recursive src tests setup.py
+    isort --check-only --diff src tests setup.py
     mypy --config-file {toxinidir}/mypy.ini src tests
 
 [testenv:docs]


### PR DESCRIPTION
Adds basic handling for sending an (optional) unique key as part of the the event. This is primarily used for deduplication of events currently. Changes are largely written to support backwards compatibility.