### PR TITLE
Add auth info from url, if any

### DIFF
--- a/src/relay_sdk/client.py
+++ b/src/relay_sdk/client.py
@@ -33,6 +33,7 @@ class MetadataAPIAdapter(HTTPAdapter):
             ),
             {},
         )
+        request.prepare_auth(None, self._base_url)
 
         return super(MetadataAPIAdapter, self).send(
             request,


### PR DESCRIPTION
Instead of using jwt bearer headers, tokens may be part of the metadata
URL as basic auth instead.