### PR TITLE
Add workflows.run support to the SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ MANIFEST
 /.tox/
 /build/
 /dist/
-venv

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ MANIFEST
 /.tox/
 /build/
 /dist/
+venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0]
+
+### Added
+
+* Add workflows run support.
+
 ## [0.1.5]
 
 ### Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0]
-
 ### Added
 
 * Add workflows run support.

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Use the following to run the workflow ``my_workflow`` with parameter ``param_nam
   from relay_sdk import Interface
 
   relay = Interface()
-  relay.workflows.run('my_workflow', {'param_name':'param_value'})
+  relay.workflows.run('my_workflow', parameters={'param_name':'param_value'})
 
 Webhook Triggers
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,21 @@ method accessors.
   secret = relay.get(D.mysecret)
   relay.outputs.set("outputkey","This will be the value of outputkey")
 
+Running Workflows
+-----------------
+
+The `Workflow class <./reference.html#module-relay_sdk.workflows>`_ offers the method ``run``
+to run a workflow.
+
+Use the following to run the workflow ``my_workflow`` with parameter ``param_name`` and value ``param_value``:
+
+.. code-block:: python
+
+  from relay_sdk import Interface
+
+  relay = Interface()
+  relay.workflows.run('my_workflow', {'param_name':'param_value'})
+
 Webhook Triggers
 ----------------
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -39,6 +39,14 @@ Outputs
 
 ----
 
+Workflows
+---------
+
+.. automodule:: relay_sdk.workflows
+   :members:
+
+----
+
 Webhook
 -------
 

--- a/src/relay_sdk/interface.py
+++ b/src/relay_sdk/interface.py
@@ -9,6 +9,7 @@ from typing import Any, Optional, Union
 from .client import new_session
 from .events import Events
 from .outputs import Outputs
+from .workflows import Workflows
 from .util import json_object_hook
 
 
@@ -93,3 +94,8 @@ class Interface:
     def outputs(self) -> Outputs:
         """Accessor for Outputs methods"""
         return Outputs(self._client)
+
+    @property
+    def workflows(self) -> Workflows:
+        """Accessor for Workflows methods"""
+        return Workflows(self._client)

--- a/src/relay_sdk/interface.py
+++ b/src/relay_sdk/interface.py
@@ -9,8 +9,8 @@ from typing import Any, Optional, Union
 from .client import new_session
 from .events import Events
 from .outputs import Outputs
-from .workflows import Workflows
 from .util import json_object_hook
+from .workflows import Workflows
 
 
 class UnresolvableException(Exception):

--- a/src/relay_sdk/workflows.py
+++ b/src/relay_sdk/workflows.py
@@ -1,0 +1,37 @@
+"Allows a step to run a workflow"
+import json
+import logging
+from typing import Any
+from urllib.parse import quote
+
+from requests import Session
+
+from .util import JSONEncoder
+
+logger = logging.getLogger(__name__)
+
+
+class Workflows:
+    """Use Workflows to run a workflow with parameters"""
+
+    def __init__(self, client: Session) -> None:
+        self._client = client
+
+    def run(self, name: str, parameters: Any = {}) -> None:
+        """run starts a workflow with name and parameters
+
+        Args:
+            name: a string containing the name of the workflow
+            parameters: an object that can serialize to JSON.
+        """
+        # transform parameters {key:value} dict into {'key': {'value':value}} format
+        params = {'parameters': {k: {'value': v}
+                                 for k, v in parameters.items()}}
+        r = self._client.post(
+            'http+api://api/workflows/{0}/run'.format(quote(name)),
+            data=json.dumps(params, cls=JSONEncoder),
+            headers={'content-type': 'application/json'},
+        )
+        r.raise_for_status()
+
+        logger.info('Run workflow %s', repr(name))

--- a/src/relay_sdk/workflows.py
+++ b/src/relay_sdk/workflows.py
@@ -2,9 +2,8 @@
 import json
 import logging
 from typing import Any
-from collections.abc import Mapping
+from typing import Mapping
 from urllib.parse import quote
-
 from requests import Session
 
 from .util import JSONEncoder
@@ -25,7 +24,7 @@ class Workflows:
             name: a string containing the name of the workflow
             parameters: an object that can serialize to JSON
         """
-        # transform parameters {key:value} dict into {'key': {'value':value}} format
+        # transform {key:value} dict into {'key': {'value':value}} format
         params = {'parameters': {k: {'value': v}
                                  for k, v in parameters.items()}}
         r = self._client.post(

--- a/src/relay_sdk/workflows.py
+++ b/src/relay_sdk/workflows.py
@@ -2,6 +2,7 @@
 import json
 import logging
 from typing import Any
+from collections.abc import Mapping
 from urllib.parse import quote
 
 from requests import Session
@@ -17,12 +18,12 @@ class Workflows:
     def __init__(self, client: Session) -> None:
         self._client = client
 
-    def run(self, name: str, parameters: Any = {}) -> None:
+    def run(self, name: str, parameters: Mapping[str, Any] = {}) -> None:
         """run starts a workflow with name and parameters
 
         Args:
             name: a string containing the name of the workflow
-            parameters: an object that can serialize to JSON.
+            parameters: an object that can serialize to JSON
         """
         # transform parameters {key:value} dict into {'key': {'value':value}} format
         params = {'parameters': {k: {'value': v}

--- a/src/relay_sdk/workflows.py
+++ b/src/relay_sdk/workflows.py
@@ -1,9 +1,9 @@
 "Allows a step to run a workflow"
 import json
 import logging
-from typing import Any
-from typing import Mapping
+from typing import Any, Mapping
 from urllib.parse import quote
+
 from requests import Session
 
 from .util import JSONEncoder

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -11,8 +11,8 @@ class TestWorkflows:
             'POST', 'http+api://api/workflows/myworkflow/run',
             text='OK',
             request_headers={'content-type': 'application/json'},
-            additional_matcher=lambda request: 
-                request.json() == {"parameters":{"foo":{"value":"bar"}}},
+            additional_matcher=lambda request:
+                request.json() == {"parameters": {"foo": {"value": "bar"}}},
         )
         Workflows(new_session(api_url='http://api')
                   ).run('myworkflow', {'foo': 'bar'})

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,18 @@
+from requests_mock import Adapter
+
+from relay_sdk.client import new_session
+from relay_sdk.workflows import Workflows
+
+
+class TestWorkflows:
+
+    def test_run(self, requests_mock: Adapter) -> None:
+        requests_mock.register_uri(
+            'POST', 'http+api://api/workflows/myworkflow/run',
+            text='OK',
+            request_headers={'content-type': 'application/json'},
+            additional_matcher=lambda request: 
+                request.json() == {"parameters":{"foo":{"value":"bar"}}},
+        )
+        Workflows(new_session(api_url='http://api')
+                  ).run('myworkflow', {'foo': 'bar'})


### PR DESCRIPTION
This PR adds the `workflows.run` metadata API method which starts a workflow run.